### PR TITLE
フォントファイルから出力される .php などの設定ファイルの出力先を、指定した$pathに設定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ class hoge{
         $TcpdfWrapper->setPrintHeader(false);
         $TcpdfWrapper->setPrintFooter(false);
 
+        // フォント設定キャッシュファイルの出力先ディレクトリを指定（任意。指定しない場合はデフォルト /vendor/tecnickcom/tcpdf/fonts に保存される）
+        $this->pdfWriter->setFontSettingCacheFileOutDir(TMP . 'pdf/');
+
         //独自フォント利用の場合
         $TcpdfWrapper->setFont('testfont', dirname(__FILE__) . '/fonts/○○.ttf');
 

--- a/src/TcpdfWrapper.php
+++ b/src/TcpdfWrapper.php
@@ -489,12 +489,13 @@ class TcpdfWrapper
     private function generateFontSettingCacheFilePath($font)
     {
         // フォントの設定キャッシュファイル出力先ディレクトリが未指定の場合
-        if (!empty($this->fontSettingCacheFileOutDir)) {
+        if (empty($this->fontSettingCacheFileOutDir)) {
             return '';
         }
 
         // TCPDFの処理の互換性のために、設定キャッシュファイル名を新たに生成
-        // 名称生成のアルゴリズムは右記参照： https://github.com/tecnickcom/TCPDF/blob/master/include/tcpdf_fonts.php#L79 〜 https://github.com/tecnickcom/TCPDF/blob/master/include/tcpdf_fonts.php#L92
+        // 名称生成のアルゴリズムは、下記URLと同様の処理で出力される必要があるため、コピーしている
+        // 参照： https://github.com/tecnickcom/TCPDF/blob/master/include/tcpdf_fonts.php#L79 〜 https://github.com/tecnickcom/TCPDF/blob/master/include/tcpdf_fonts.php#L92
         $fontPathParts = pathinfo($font);
         if (!isset($fontPathParts['filename'])) {
             $fontPathParts['filename'] = substr($fontPathParts['basename'], 0, -(strlen($fontPathParts['extension']) + 1));
@@ -508,6 +509,7 @@ class TcpdfWrapper
             return 'tcpdffont' . '.php';
         }
 
+        // 出力ディレクトリを設定した場合、そこに [生成されたフォント名].php で生成されているので、そのpathを返す
         return $this->fontSettingCacheFileOutDir . $fontName . '.php';
     }
 }

--- a/src/TcpdfWrapper.php
+++ b/src/TcpdfWrapper.php
@@ -152,11 +152,12 @@ class TcpdfWrapper
 
     /**
      * setFontFilePath
+     * setFont($name, $path)で指定された$pathをプロパティにセット
      *
      * @param string $fontFilePath 読み込みフォントファイルのパス
      * @return void
      */
-    public function setFontFilePath($fontFilePath)
+    private function setFontFilePath($fontFilePath)
     {
         $this->fontFilePath = $fontFilePath;
     }
@@ -171,6 +172,8 @@ class TcpdfWrapper
     public function setFont($name, $path)
     {
         $this->__fonts[$name] = $this->__tcpdfFonts->addTTFfont($path, '', '', 32, $this->fontSettingCacheFileOutDir);
+        // 読み込むフォントファイルのパスを設定
+        $this->setFontFilePath($path);
     }
 
     /**
@@ -484,7 +487,7 @@ class TcpdfWrapper
     /**
      * フォント設定キャッシュファイルのパスを返す
      * $this->fontSettingCacheFileOutDir (上記ファイルの出力先ディレクトリ) を指定した場合のみ呼ばれる
-     * [関数中ののアルゴリズムで生成されたフォント名].php が作られているので、そのpathを返す
+     * [関数中のアルゴリズムで生成されたフォント名].php が作られているので、そのpathを返す
      * @param string $font フォント名
      * @return string
      * @author kawano

--- a/src/TcpdfWrapper.php
+++ b/src/TcpdfWrapper.php
@@ -484,6 +484,7 @@ class TcpdfWrapper
     /**
      * フォント設定キャッシュファイルのパスを返す
      * $this->fontSettingCacheFileOutDir (上記ファイルの出力先ディレクトリ) を指定した場合のみ呼ばれる
+     * [関数中ののアルゴリズムで生成されたフォント名].php が作られているので、そのpathを返す
      * @param string $font フォント名
      * @return string
      * @author kawano
@@ -513,7 +514,6 @@ class TcpdfWrapper
             return $this->fontSettingCacheFileOutDir . 'tcpdffont' . '.php';
         }
 
-        // 出力ディレクトリを設定した場合、そこに [生成されたフォント名].php で生成されているので、そのpathを返す
         return $this->fontSettingCacheFileOutDir . $fontName . '.php';
     }
 }

--- a/src/TcpdfWrapper.php
+++ b/src/TcpdfWrapper.php
@@ -13,7 +13,7 @@ class TcpdfWrapper
     private $__pdf;
     private $__fonts = [];
     private $__tcpdfFonts;
-    // fontの設定キャッシュファイル出力先ディレクトリ
+    // フォントの設定キャッシュファイル出力先ディレクトリ
     private $fontSettingCacheFileOutDir = '';
 
     const TATEGAKI_TYPE_NORMAL = 1;
@@ -230,10 +230,7 @@ class TcpdfWrapper
         }
         
         // 書き込む文字列のフォントを指定（フォントの設定キャッシュファイルの出力先がセットされていない場合はデフォルト値）
-        $fontFilePath = '';
-        if (!empty($this->fontSettingCacheFileOutDir)) {
-            $fontFilePath = $this->generateFontSettingCacheFilePath($option['font']);
-        }
+        $fontFilePath = $this->generateFontSettingCacheFilePath($option['font']);
         $this->__pdf->SetFont($this->getFont($option['font']), '', $option['size'], $fontFilePath);
         // 書き込む文字列の文字色を指定
         $concertColor = $this->colorCodeConvert($option['color']);
@@ -373,10 +370,7 @@ class TcpdfWrapper
         //$this->__pdf->SetTextColor($concertColor['r'], $concertColor['g'], $concertColor['b']);
 
         // 書き込む文字列のフォントを指定（フォントの設定キャッシュファイルの出力先がセットされていない場合はデフォルト値）
-        $fontFilePath = '';
-        if (!empty($this->fontSettingCacheFileOutDir)) {
-            $fontFilePath = $this->generateFontSettingCacheFilePath($option['font']);
-        }
+        $fontFilePath = $this->generateFontSettingCacheFilePath($option['font']);
         $this->__pdf->SetFont($this->getFont($option['font']), '', $option['size'], $fontFilePath);
         
         $this->__pdf->writeHTMLCell( $option['w'], $option['h'], $option['x'], $option['y'], $html, $option['border'], 0, $option['fill'], $option['reseth'], $option['align'], $option['autopadding']);
@@ -488,27 +482,32 @@ class TcpdfWrapper
     /**
      * フォント設定キャッシュファイルのパスを返す
      * $this->fontSettingCacheFileOutDir (上記ファイルの出力先ディレクトリ) を指定した場合のみ呼ばれる
-     * ファイル名生成アルゴリズム部分は右記を参照： https://github.com/tecnickcom/TCPDF/blob/master/include/tcpdf_fonts.php#L79 〜 https://github.com/tecnickcom/TCPDF/blob/master/include/tcpdf_fonts.php#L92
      * @param string $font フォント名
      * @return string
      * @author kawano
      */
     private function generateFontSettingCacheFilePath($font)
     {
-        // build new font name for TCPDF compatibility
-        $font_path_parts = pathinfo($font);
-        if (!isset($font_path_parts['filename'])) {
-            $font_path_parts['filename'] = substr($font_path_parts['basename'], 0, -(strlen($font_path_parts['extension']) + 1));
+        // フォントの設定キャッシュファイル出力先ディレクトリが未指定の場合
+        if (!empty($this->fontSettingCacheFileOutDir)) {
+            return '';
         }
-        $font_name = strtolower($font_path_parts['filename']);
-        $font_name = preg_replace('/[^a-z0-9_]/', '', $font_name);
+
+        // TCPDFの処理の互換性のために、設定キャッシュファイル名を新たに生成
+        // 名称生成のアルゴリズムは右記参照： https://github.com/tecnickcom/TCPDF/blob/master/include/tcpdf_fonts.php#L79 〜 https://github.com/tecnickcom/TCPDF/blob/master/include/tcpdf_fonts.php#L92
+        $fontPathParts = pathinfo($font);
+        if (!isset($fontPathParts['filename'])) {
+            $fontPathParts['filename'] = substr($fontPathParts['basename'], 0, -(strlen($fontPathParts['extension']) + 1));
+        }
+        $fontName = strtolower($fontPathParts['filename']);
+        $fontName = preg_replace('/[^a-z0-9_]/', '', $fontName);
         $search  = array('bold', 'oblique', 'italic', 'regular');
         $replace = array('b', 'i', 'i', '');
-        $font_name = str_replace($search, $replace, $font_name);
-        if (empty($font_name)) {
+        $fontName = str_replace($search, $replace, $fontName);
+        if (empty($fontName)) {
             return 'tcpdffont' . '.php';
         }
 
-        return $this->fontSettingCacheFileOutDir . $font_name . '.php';
+        return $this->fontSettingCacheFileOutDir . $fontName . '.php';
     }
 }

--- a/src/TcpdfWrapper.php
+++ b/src/TcpdfWrapper.php
@@ -232,7 +232,7 @@ class TcpdfWrapper
         // 書き込む文字列のフォントを指定（フォントの設定キャッシュファイルの出力先がセットされていない場合はデフォルト値）
         $fontFilePath = '';
         if (!empty($this->fontSettingCacheFileOutDir)) {
-            $fontFilePath = $this->generateFontFilePath($option['font']);
+            $fontFilePath = $this->generateFontSettingCacheFilePath($option['font']);
         }
         $this->__pdf->SetFont($this->getFont($option['font']), '', $option['size'], $fontFilePath);
         // 書き込む文字列の文字色を指定
@@ -375,7 +375,7 @@ class TcpdfWrapper
         // 書き込む文字列のフォントを指定（フォントの設定キャッシュファイルの出力先がセットされていない場合はデフォルト値）
         $fontFilePath = '';
         if (!empty($this->fontSettingCacheFileOutDir)) {
-            $fontFilePath = $this->generateFontFilePath($option['font']);
+            $fontFilePath = $this->generateFontSettingCacheFilePath($option['font']);
         }
         $this->__pdf->SetFont($this->getFont($option['font']), '', $option['size'], $fontFilePath);
         
@@ -493,7 +493,7 @@ class TcpdfWrapper
      * @return string
      * @author kawano
      */
-    private function generateFontFilePath($font)
+    private function generateFontSettingCacheFilePath($font)
     {
         // build new font name for TCPDF compatibility
         $font_path_parts = pathinfo($font);

--- a/tests/TcpdfWrapperTest.php
+++ b/tests/TcpdfWrapperTest.php
@@ -229,9 +229,13 @@ class TcpdfWrapperTest extends TestCase
         $privateFunctionGenerateFontSettingCacheFilePath = $reflection->getMethod('generateFontSettingCacheFilePath');
         $privateFunctionGenerateFontSettingCacheFilePath->setAccessible(true);
 
+        // 出力先ディレクトリを指定
         $TcpdfWrapper->setFontSettingCacheFileOutDir($fontSettingCacheFileOutDir);
+        // フォントをセット
         $TcpdfWrapper->setFont($font, $fontFile);
+        // 出力したファイルのパスを取得
         $fontFile = $privateFunctionGenerateFontSettingCacheFilePath->invoke($TcpdfWrapper, $font);
+        // パスにファイルがあるか確認
         $this->assertTrue(file_exists($fontFile));
     }
 }

--- a/tests/TcpdfWrapperTest.php
+++ b/tests/TcpdfWrapperTest.php
@@ -18,6 +18,17 @@ class TcpdfWrapperTest extends TestCase
             mkdir($this->__tmpDir);
         }
 
+        // フォント設定キャッシュファイルがあれば削除
+        if (file_exists($this->__tmpDir . '/testfont.ctg.z')) {
+            unlink($this->__tmpDir . '/testfont.ctg.z');
+        }
+        if (file_exists($this->__tmpDir . '/testfont.php')) {
+            unlink($this->__tmpDir . '/testfont.php');
+        }
+        if (file_exists($this->__tmpDir . '/testfont.z')) {
+            unlink($this->__tmpDir . '/testfont.z');
+        }
+
         //出力ファイルがいたら削除
         $this->__exportFile = $this->__tmpDir . '/export.pdf';
         if (file_exists($this->__exportFile)) {
@@ -196,18 +207,31 @@ class TcpdfWrapperTest extends TestCase
         $this->assertTrue(file_exists($this->__exportFile));
     }
 
-    public function test_check_if_font_setting_cache_file_output()
+    /**
+     * test_checkIfFontSettingCacheFileOutDir
+     * フォント設定キャッシュファイルが、指定したディレクトリに出力されるかのテスト
+     *
+     * @return void
+     * @author kawano
+     */
+    public function test_checkIfFontSettingCacheFileOutDir()
     {
+        $font = 'testfont';
+        $fontSettingCacheFileOutDir = dirname(dirname(__FILE__)) . '/tmp/';
+        $fontFile = dirname(__FILE__) . '/file/testfont.ttf';
+
         $TcpdfWrapper = new TcpdfWrapper();
         $TcpdfWrapper->setPrintHeader(false);
         $TcpdfWrapper->setPrintFooter(false);
 
-        $font = 'testfont';
-        $fontSettingCacheFileOutDir = dirname(__FILE__) . '/../tmp/';
-        $fontFile = dirname(__FILE__) . '/file/testfont.ttf';
+        // private function generateFontSettingCacheFilePath() を使う用意
+        $reflection = new \ReflectionClass($TcpdfWrapper);
+        $privateFunctionGenerateFontSettingCacheFilePath = $reflection->getMethod('generateFontSettingCacheFilePath');
+        $privateFunctionGenerateFontSettingCacheFilePath->setAccessible(true);
+
         $TcpdfWrapper->setFontSettingCacheFileOutDir($fontSettingCacheFileOutDir);
         $TcpdfWrapper->setFont($font, $fontFile);
-        // var_dump($fontFile);exit;
-        // var_dump(file_exists($fontFile));exit;
+        $fontFile = $privateFunctionGenerateFontSettingCacheFilePath->invoke($TcpdfWrapper, $font);
+        $this->assertTrue(file_exists($fontFile));
     }
 }

--- a/tests/TcpdfWrapperTest.php
+++ b/tests/TcpdfWrapperTest.php
@@ -196,4 +196,18 @@ class TcpdfWrapperTest extends TestCase
         $this->assertTrue(file_exists($this->__exportFile));
     }
 
+    public function test_check_if_font_setting_cache_file_output()
+    {
+        $TcpdfWrapper = new TcpdfWrapper();
+        $TcpdfWrapper->setPrintHeader(false);
+        $TcpdfWrapper->setPrintFooter(false);
+
+        $font = 'testfont';
+        $fontSettingCacheFileOutDir = dirname(__FILE__) . '/../tmp/';
+        $fontFile = dirname(__FILE__) . '/file/testfont.ttf';
+        $TcpdfWrapper->setFontSettingCacheFileOutDir($fontSettingCacheFileOutDir);
+        $TcpdfWrapper->setFont($font, $fontFile);
+        // var_dump($fontFile);exit;
+        // var_dump(file_exists($fontFile));exit;
+    }
 }


### PR DESCRIPTION
### やったこと
- [x] フォントファイル (.ttfなど)を読み込ませた際の、フォント設定キャッシュファイルが出力されるディレクトリを指定可能にした
- [x] 読み込んだフォントファイルの設定キャッシュファイルが、指定ディレクトリに出力されるかテスト

### チェック項目
- [x] ディレクトリを設定しない場合は、デフォルトのディレクトリに出力される